### PR TITLE
feat: 支持 xqshare 远程后端

### DIFF
--- a/src/xtquantai/server.py
+++ b/src/xtquantai/server.py
@@ -35,24 +35,37 @@ xtdata = None
 UIPanel = None
 
 try:
-    from xtquant import xtdata
-    print(f"成功导入xtquant模块，路径: {xtdata.__file__ if hasattr(xtdata, '__file__') else '未知'}")
-    
-    # 尝试导入UIPanel，如果不存在则创建一个模拟的UIPanel类
-    try:
-        from xtquant.xtdata import UIPanel
-        print("成功导入UIPanel类")
-    except ImportError as e:
-        print(f"警告: 无法导入UIPanel类: {str(e)}")
-        # 创建一个模拟的UIPanel类
-        class UIPanel:
-            def __init__(self, stock, period, figures=None):
-                self.stock = stock
-                self.period = period
-                self.figures = figures or []
-            
-            def __str__(self):
-                return f"UIPanel(stock={self.stock}, period={self.period}, figures={self.figures})"
+    # 如果配置了 xqshare 环境变量，使用 xqshare 远程后端
+    if os.environ.get("XQSHARE_REMOTE_HOST"):
+        from xqshare import connect, xtdata
+        connect()
+        print("使用 xqshare 远程后端")
+        # 尝试导入 UIPanel
+        try:
+            from xqshare import xtview
+            UIPanel = xtview.UIPanel
+            print("成功导入 UIPanel (from xqshare.xtview)")
+        except (ImportError, AttributeError):
+            print("警告: xqshare 中无 UIPanel，UI 面板功能不可用")
+    else:
+        from xtquant import xtdata
+        print(f"成功导入xtquant模块，路径: {xtdata.__file__ if hasattr(xtdata, '__file__') else '未知'}")
+
+        # 尝试导入UIPanel，如果不存在则创建一个模拟的UIPanel类
+        try:
+            from xtquant.xtdata import UIPanel
+            print("成功导入UIPanel类")
+        except ImportError as e:
+            print(f"警告: 无法导入UIPanel类: {str(e)}")
+            # 创建一个模拟的UIPanel类
+            class UIPanel:
+                def __init__(self, stock, period, figures=None):
+                    self.stock = stock
+                    self.period = period
+                    self.figures = figures or []
+
+                def __str__(self):
+                    return f"UIPanel(stock={self.stock}, period={self.period}, figures={self.figures})"
 except ImportError as e:
     print(f"警告: 无法导入xtquant模块: {str(e)}")
     print("Python搜索路径:")


### PR DESCRIPTION
## Summary

- 添加 `XQSHARE_REMOTE_HOST` 环境变量检测
- 配置环境变量时使用 xqshare 远程连接 xtquant
- 未配置时保持原有本地 xtquant 或 Mock 模式
- 支持 Mac/Linux 上通过 xqshare 运行

## 使用方式

```bash
# Mac/Linux 上使用（配置 xqshare 环境变量）
export XQSHARE_REMOTE_HOST=192.168.1.100  # Windows 端 IP
xtquantai

# Windows 上使用（默认本地 xtquant）
xtquantai
```

## 测试

- ✅ `get_trading_dates` - 返回交易日期
- ✅ `get_stock_list` - 返回股票列表
- ✅ 8 个 MCP 工具全部可用

## Related Issue

Closes #7